### PR TITLE
chore(node): drop Node 8 support

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,7 +4,7 @@ module.exports = {
       '@babel/preset-env',
       {
         targets: {
-          node: 8,
+          node: 10,
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "homepage": "https://wkovacs64.github.io/pwned",
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   },
   "dependencies": {
     "common-tags": "^1.8.0",


### PR DESCRIPTION
BREAKING CHANGE: Support for Node.js version 8.x has been dropped.