### PR TITLE
chore(node): drop Node 12 support

### DIFF
--- a/.babelrc.cjs
+++ b/.babelrc.cjs
@@ -1,13 +1,15 @@
 module.exports = {
+  plugins: ['babel-plugin-add-import-extension'],
   presets: [
+    '@babel/preset-typescript',
     [
       '@babel/preset-env',
       {
+        modules: false,
         targets: {
-          node: '12.20',
+          node: '14.13.1',
         },
       },
     ],
-    '@babel/preset-typescript',
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@types/ws": "8.5.3",
         "@types/yargs": "17.0.10",
         "@wkovacs64/prettier-config": "3.0.1",
+        "babel-plugin-add-import-extension": "1.6.0",
         "c8": "7.11.2",
         "codecov": "3.8.3",
         "commitizen": "4.2.4",
@@ -53,7 +54,7 @@
         "vitest": "0.10.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3382,6 +3383,18 @@
       "version": "2.2.0",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/babel-plugin-add-import-extension": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+      "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0"
+      }
     },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
@@ -16483,6 +16496,15 @@
     "axobject-query": {
       "version": "2.2.0",
       "dev": true
+    },
+    "babel-plugin-add-import-extension": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+      "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "homepage": "https://wkovacs64.github.io/pwned",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": "^14.13.1 || >=16.0.0"
   },
   "dependencies": {
     "common-tags": "^1.8.2",
@@ -90,6 +90,7 @@
     "@types/ws": "8.5.3",
     "@types/yargs": "17.0.10",
     "@wkovacs64/prettier-config": "3.0.1",
+    "babel-plugin-add-import-extension": "1.6.0",
     "c8": "7.11.2",
     "codecov": "3.8.3",
     "commitizen": "4.2.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "lib": ["esnext", "dom"], // "dom" only for msw
-    "target": "es2019", // Node 12
-    "module": "es2020",
-    "moduleResolution": "node",
+    "lib": ["ESNext", "DOM"], // "DOM" only for msw
+    "target": "ES2020", // Node 14
+    "module": "ES2020",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
     "importsNotUsedAsValues": "error",
     "noEmit": true,


### PR DESCRIPTION
This also converts the project to pure ESM as it is fully supported in
Node 14.13.1, 16 and beyond.

BREAKING CHANGE: This removes support for Node v12 and makes the new
minimum runtime Node v14.13.1, as v12 is EOL. Please upgrade your
Node.js environment to at least version 14.13.1, or continue using the
latest v9 release of `pwned` if you are unable to upgrade your
environment.