### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
-  "extends": ["config:base", ":semanticCommits"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":semanticCommits", ":semanticCommitTypeAll(chore)"],
   "commitMessageTopic": "{{depName}}",
   "automergeType": "branch",
   "automerge": true,
@@ -8,11 +9,18 @@
   },
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
       "matchPackageNames": ["eslint"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["minor"],
+      "automerge": false
     }
-  ],
-  "prConcurrentLimit": 0,
-  "prHourlyLimit": 0
+  ]
 }


### PR DESCRIPTION
Updates renovate.json to the new standardized configuration:

- Adds `$schema` for validation
- Adds `minimumReleaseAge` of 7 days for npm packages
- Adds typescript minor update automerge disabled rule
- Removes `prConcurrentLimit` and `prHourlyLimit` (using defaults)
- Uses modern `matchPackageNames`/`matchUpdateTypes` syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration with refined package update policies.
  * Adjusted settings for npm, TypeScript, and ESLint package updates to optimize release cadence and stability.
  * Modified pull request handling parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->