### PR TITLE
chore: fix lint warnings

### DIFF
--- a/src/commands/__tests__/ba.test.ts
+++ b/src/commands/__tests__/ba.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -17,16 +10,15 @@ import {
   ERROR_MSG,
   NONE,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as ba } from "../ba.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: ba", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/bd.test.ts
+++ b/src/commands/__tests__/bd.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -15,16 +8,15 @@ import {
   ERROR,
   ERROR_MSG,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as bd } from "../bd.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: bd", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/breach.test.ts
+++ b/src/commands/__tests__/breach.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -16,16 +9,15 @@ import {
   ERROR,
   ERROR_MSG,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as breach } from "../breach.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: breach", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/breaches.test.ts
+++ b/src/commands/__tests__/breaches.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -16,16 +9,15 @@ import {
   ERROR,
   ERROR_MSG,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as breaches } from "../breaches.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: breaches", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/dc.test.ts
+++ b/src/commands/__tests__/dc.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -14,16 +7,15 @@ import {
   EMPTY_ARRAY,
   ERROR_MSG,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as dc } from "../dc.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: dc", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/lb.test.ts
+++ b/src/commands/__tests__/lb.test.ts
@@ -1,24 +1,16 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import { spinnerFns, loggerFns, ERROR_MSG } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as lb } from "../lb.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: lb", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/pa.test.ts
+++ b/src/commands/__tests__/pa.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -16,16 +9,15 @@ import {
   ERROR,
   ERROR_MSG,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as pa } from "../pa.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: pa", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/pw.test.ts
+++ b/src/commands/__tests__/pw.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -16,16 +9,15 @@ import {
   ERROR,
   ERROR_MSG,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as pw } from "../pw.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: pw", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/sd.test.ts
+++ b/src/commands/__tests__/sd.test.ts
@@ -1,24 +1,16 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import { spinnerFns, loggerFns, ERROR_MSG } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as sd } from "../sd.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: sd", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/search.test.ts
+++ b/src/commands/__tests__/search.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -17,16 +10,15 @@ import {
   ERROR_MSG,
   NONE,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as search } from "../search.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: search", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/slbe.test.ts
+++ b/src/commands/__tests__/slbe.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -15,16 +8,15 @@ import {
   ERROR,
   ERROR_MSG,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as slbe } from "../slbe.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: slbe", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/slbed.test.ts
+++ b/src/commands/__tests__/slbed.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -15,16 +8,15 @@ import {
   ERROR,
   ERROR_MSG,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as slbed } from "../slbed.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: slbed", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/slbwd.test.ts
+++ b/src/commands/__tests__/slbwd.test.ts
@@ -1,11 +1,4 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import {
@@ -15,16 +8,15 @@ import {
   ERROR,
   ERROR_MSG,
 } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as slbwd } from "../slbwd.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: slbwd", () => {
   describe("normal output (default)", () => {

--- a/src/commands/__tests__/sub-status.test.ts
+++ b/src/commands/__tests__/sub-status.test.ts
@@ -1,24 +1,16 @@
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http } from "msw";
 import { server } from "../../../test/server.js";
 import { spinnerFns, loggerFns, ERROR_MSG } from "../../../test/fixtures.js";
-import { logger as mockLogger, type Logger } from "../../utils/logger.js";
+import { logger as mockLogger } from "../../utils/logger.js";
 import { spinner as mockSpinner } from "../../utils/spinner.js";
 import { handler as subStatus } from "../sub-status.js";
 
 vi.mock("../../utils/logger");
 vi.mock("../../utils/spinner");
 
-const logger = mockLogger as Logger & Record<string, MockInstance>;
-const spinner = mockSpinner as typeof mockSpinner &
-  Record<string, MockInstance>;
+const logger = vi.mocked(mockLogger);
+const spinner = vi.mocked(mockSpinner);
 
 describe("command: subStatus", () => {
   describe("normal output (default)", () => {

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,13 +1,6 @@
-import { describe, expect, it, vi, type MockInstance } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { loggerFns } from "../../../test/fixtures.js";
-import { logger, type Logger, type LoggerFunction } from "../logger.js";
-
-type IndexableConsole = typeof console &
-  Record<string, LoggerFunction | MockInstance>;
-type IndexableLogger = Logger & Record<string, LoggerFunction>;
-
-const indexableConsole = console as IndexableConsole;
-const indexableLogger = logger as IndexableLogger;
+import { logger, type LoggerFunction } from "../logger.js";
 
 describe("util: logger", () => {
   it("returns an object with all the expected methods", () => {
@@ -27,13 +20,14 @@ describe("util: logger", () => {
   it("calls the corresponding console functions with the same arguments", () => {
     const args = ["Wubba lubba dub dub!", { param: "value" }];
     loggerFns.forEach((fn) => {
-      const orig = indexableConsole[fn];
-      indexableConsole[fn] = vi.fn<LoggerFunction>();
-      expect(indexableConsole[fn]).toHaveBeenCalledTimes(0);
-      indexableLogger[fn](...args);
-      expect(indexableConsole[fn]).toHaveBeenCalledTimes(1);
-      expect(indexableConsole[fn]).toHaveBeenCalledWith(...args);
-      indexableConsole[fn] = orig;
+      const mock = vi
+        .spyOn(console, fn)
+        .mockImplementation(vi.fn<LoggerFunction>());
+      expect(mock).toHaveBeenCalledTimes(0);
+      logger[fn](...args);
+      expect(mock).toHaveBeenCalledTimes(1);
+      expect(mock).toHaveBeenCalledWith(...args);
+      mock.mockRestore();
     });
   });
 });

--- a/src/utils/pkg.ts
+++ b/src/utils/pkg.ts
@@ -1,10 +1,25 @@
 import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
-import type { PackageJson } from "type-fest";
 
 const dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
-export const pkg = JSON.parse(
+const parsedPackage: unknown = JSON.parse(
   fs.readFileSync(path.join(dirname, "..", "..", "package.json"), "utf8"),
-) as PackageJson;
+);
+
+if (
+  typeof parsedPackage !== "object" ||
+  parsedPackage === null ||
+  !("name" in parsedPackage) ||
+  typeof parsedPackage.name !== "string" ||
+  !("version" in parsedPackage) ||
+  typeof parsedPackage.version !== "string"
+) {
+  throw new TypeError("Invalid package.json");
+}
+
+export const pkg = {
+  name: parsedPackage.name,
+  version: parsedPackage.version,
+};

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -8,8 +8,8 @@ import type {
   SubscriptionStatus,
 } from "hibp";
 
-export const spinnerFns = ["start", "stop", "succeed", "warn", "fail"];
-export const loggerFns = ["info", "log", "warn", "error"];
+export const spinnerFns = ["start", "stop", "succeed", "warn", "fail"] as const;
+export const loggerFns = ["info", "log", "warn", "error"] as const;
 
 export const DATA_CLASSES = ["foo", "bar"];
 export const BREACH: Breach = {


### PR DESCRIPTION
## Summary
- replace test mock assertions with Vitest helpers
- narrow package metadata after parsing
- type fixture method lists as tuples

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`